### PR TITLE
Update layers.py

### DIFF
--- a/tensorlayer/layers.py
+++ b/tensorlayer/layers.py
@@ -1308,7 +1308,7 @@ class BatchNormLayer(Layer):
         self,
         layer = None,
         decay = 0.999,
-        epsilon = 0.001,
+        epsilon = 0.00001,
         is_train = None,
         name ='batchnorm_layer',
     ):


### PR DESCRIPTION
Modify the default epsilon value in BatchNormLayer from 0.001 to 0.00001. 0.001 is too big in some situations. 0.00001 is used in other deep learning frameworks (for example, Caffe).