### PR TITLE
force matplotlib backend to Agg

### DIFF
--- a/tensorlayer/visualize.py
+++ b/tensorlayer/visualize.py
@@ -2,7 +2,9 @@
 # -*- coding: utf8 -*-
 
 
-
+import matplotlib
+# Force matplotlib to not use any Xwindows backend.
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 import os


### PR DESCRIPTION
When visualized some parameters using tensorlayer in Ubuntu server,  I met an error:
**_tkinter.TclError: no display name and no $DISPLAY environment variable**

It seems that the error was raised by matplotlib, which use an x-using backend by default. So I force matplotlib using Agg as backend, and then the error was fixed. Some discussions can be found in [StackOverflow](http://stackoverflow.com/questions/2801882/generating-a-png-with-matplotlib-when-display-is-undefined)

Please review this change. Thanks!