### PR TITLE
Update layers.py

### DIFF
--- a/tensorlayer/layers.py
+++ b/tensorlayer/layers.py
@@ -1733,7 +1733,7 @@ class BatchNormLayer(Layer):
                                         trainable=False)
             moving_variance = _get_variable('moving_variance',
                                             params_shape,
-                                            initializer=tf.ones_initializer,
+                                            initializer=tf.ones_initializer(),
                                             trainable=False)
 
             # These ops will only be preformed when training.


### PR DESCRIPTION
The init_ops.one_initializer() function is rewritten on tensorflow 0.12. Maybe 'tf.one_initializer' should be replaced by 'tf.one_initializer()' in tensorlayer for tensorflow 0.12. But i did not check it for tensorflow 0.11 backend.