### PR TITLE
Fix batchnormlayer compatibility to TF12

### DIFF
--- a/tensorlayer/layers.py
+++ b/tensorlayer/layers.py
@@ -1719,9 +1719,14 @@ class BatchNormLayer(Layer):
             beta = _get_variable('beta',
                                  params_shape,
                                  initializer=beta_init)
-            gamma = _get_variable('gamma',
-                                  params_shape,
-                                  initializer=gamma_init)
+            try: # TF12
+                gamma = _get_variable('gamma',
+                                      params_shape,
+                                      initializer=gamma_init())
+            except: # TF11
+                gamma = _get_variable('gamma',
+                                      params_shape,
+                                      initializer=gamma_init)
 
             # trainable=False means : it prevent TF from updating this variable
             # from the gradient, we have to update this from the mean computed


### PR DESCRIPTION
Since the default argument of gama_init is ones_initializer and the change of api in TF12. Though it can be fixed by user to specify the gama_init argument to be ones_initializer() it's easier for newbie to avoid this issue by revising the source code of tensorlayer.