### PR TITLE
Fix BUG in Python3.5

### DIFF
--- a/tensorlayer/nlp.py
+++ b/tensorlayer/nlp.py
@@ -394,7 +394,7 @@ def simple_read_words(filename="nietzsche.txt"):
         words = f.read()
         return words
 
-def read_words(filename="nietzsche.txt", replace = ['\n', '<eos>']):
+def read_words(filename="nietzsche.txt", replace = [b'\n', b'<eos>']):
     """File to list format context. Note that, this script can not handle punctuations.
     For customized read_words method, see ``tutorial_generate_text.py``.
 

--- a/tensorlayer/nlp.py
+++ b/tensorlayer/nlp.py
@@ -394,7 +394,7 @@ def simple_read_words(filename="nietzsche.txt"):
         words = f.read()
         return words
 
-def read_words(filename="nietzsche.txt", replace = [b'\n', b'<eos>']):
+def read_words(filename="nietzsche.txt", replace = ['\n', '<eos>']):
     """File to list format context. Note that, this script can not handle punctuations.
     For customized read_words method, see ``tutorial_generate_text.py``.
 
@@ -415,7 +415,12 @@ def read_words(filename="nietzsche.txt", replace = [b'\n', b'<eos>']):
     - `tensorflow.models.rnn.ptb.reader <https://github.com/tensorflow/tensorflow/tree/master/tensorflow/models/rnn/ptb>`_
     """
     with tf.gfile.GFile(filename, "r") as f:
-        return f.read().replace(*replace).split()
+        try:
+            context_list = f.read().replace(*replace).split()
+        except:
+            replace = [x.encode('utf-8') for x in replace]
+            context_list = f.read().replace(*replace).split()
+        return context_list
 
 def read_analogies_file(eval_file='questions-words.txt', word2id={}):
     """Reads through an analogy question file, return its id format.


### PR DESCRIPTION
To make the read_words function can be used in Python3.5 without a BUG "TypeError: a bytes-like object is required, not 'str'"