### PR TITLE
Bug fix, tf 0.12 compatibility, for expamples/tutorial_cifar10_tfrecords.py

### DIFF
--- a/example/tutorial_cifar10_tfrecord.py
+++ b/example/tutorial_cifar10_tfrecord.py
@@ -113,7 +113,11 @@ def read_and_decode(filename, is_train=None):
         # 4. Randomly change contrast.
         img = tf.image.random_contrast(img, lower=0.2, upper=1.8)
         # 5. Subtract off the mean and divide by the variance of the pixels.
-        img = tf.image.per_image_whitening(img)
+        try: # TF12
+            img = tf.image.per_image_standardization(img)
+        except: #earlier TF versions
+            img = tf.image.per_image_whitening(img)
+
     elif is_train == False:
         # 1. Crop the central [height, width] of the image.
         img = tf.image.resize_image_with_crop_or_pad(img, 24, 24)
@@ -246,7 +250,7 @@ with tf.device('/cpu:0'):
         with tf.variable_scope("model", reuse=reuse):
             tl.layers.set_name_reuse(reuse)
             network = tl.layers.InputLayer(x_crop, name='input_layer')
-            
+
             network = tl.layers.Conv2dLayer(network, act=tf.identity,
                         shape=[5, 5, 3, 64], strides=[1, 1, 1, 1], padding='SAME', # 64 features for each 5x5x3 patch
                         W_init=W_init, b_init=None, name='cnn_layer1')                            # output: (batch_size, 24, 24, 64)

--- a/example/tutorial_cifar10_tfrecord.py
+++ b/example/tutorial_cifar10_tfrecord.py
@@ -122,7 +122,10 @@ def read_and_decode(filename, is_train=None):
         # 1. Crop the central [height, width] of the image.
         img = tf.image.resize_image_with_crop_or_pad(img, 24, 24)
         # 2. Subtract off the mean and divide by the variance of the pixels.
-        img = tf.image.per_image_whitening(img)
+        try: # TF12
+            img = tf.image.per_image_standardization(img)
+        except: #earlier TF versions
+            img = tf.image.per_image_whitening(img)
     elif is_train == None:
         img = img
 


### PR DESCRIPTION
fixes #69
Simple compatibility fix, 
`tf.image.per_image_whitening(img)`
has apparently been replaced by
`tf.image.per_image_standardization`
in tf 0.12