### PR TITLE
Fix #33 BatchNormalLayer error on Tensorflow 0.12.1 with python3.5

### DIFF
--- a/tensorlayer/layers.py
+++ b/tensorlayer/layers.py
@@ -1872,7 +1872,7 @@ class BatchNormLayer(Layer):
         epsilon = 0.00001,
         act = tf.identity,
         is_train = False,
-        beta_init = tf.zeros_initializer,
+        beta_init = tf.ones_initializer(),
         # gamma_init = tf.ones_initializer,
         gamma_init = tf.random_normal_initializer(mean=1.0, stddev=0.002),
         name ='batchnorm_layer',
@@ -1953,7 +1953,7 @@ class BatchNormLayer(Layer):
 
             moving_mean = tf.get_variable('moving_mean',
                                       params_shape,
-                                      initializer=tf.zeros_initializer,
+                                      initializer=tf.zeros_initializer(),
                                       trainable=False,)#   restore=restore)
             moving_variance = tf.get_variable('moving_variance',
                                           params_shape,


### PR DESCRIPTION
Issue #33 are still problem with tensorlayer version 1.3.4.
I've only tested `BatchNormalLayer` with tf 0.12.1 and python 3.5.


Error stack trace.
```
File "/data/venv/ndate-tf/lib/python3.5/site-packages/tensorflow/python/ops/variable_scope.py", line 711, in _get_single_variable
  validate_shape=validate_shape)
File "/data/venv/ndate-tf/lib/python3.5/site-packages/tensorflow/python/ops/variables.py", line 226, in __init__
  expected_shape=expected_shape)
File "/data/venv/ndate-tf/lib/python3.5/site-packages/tensorflow/python/ops/variables.py", line 303, in _init_from_args
  initial_value(), name="initial_value", dtype=dtype)
File "/data/venv/ndate-tf/lib/python3.5/site-packages/tensorflow/python/ops/variable_scope.py", line 687, in <lambda>
  shape.as_list(), dtype=dtype, partition_info=partition_info)
TypeError: __init__() got an unexpected keyword argument 'partition_info'
```
