### PR TITLE
bug fix on win10_x86_64

### DIFF
--- a/example/tutorial_mnist.py
+++ b/example/tutorial_mnist.py
@@ -164,7 +164,7 @@ def main_test_layers(model='relu'):
     # Add ops to save and restore all the variables, including variables for training.
     # ref: https://www.tensorflow.org/versions/r0.8/how_tos/variables/index.html
     saver = tf.train.Saver()
-    save_path = saver.save(sess, "model.ckpt")
+    save_path = saver.save(sess, "./model.ckpt")
     print("Model saved in file: %s" % save_path)
 
 
@@ -243,7 +243,7 @@ def main_test_denoise_AE(model='relu'):
     # ref: https://www.tensorflow.org/versions/r0.8/how_tos/variables/index.html
     saver = tf.train.Saver()
     # you may want to save the model
-    save_path = saver.save(sess, "model.ckpt")
+    save_path = saver.save(sess, "./model.ckpt")
     print("Model saved in file: %s" % save_path)
     sess.close()
 
@@ -405,7 +405,7 @@ def main_test_stacked_denoise_AE(model='relu'):
     # ref: https://www.tensorflow.org/versions/r0.8/how_tos/variables/index.html
     saver = tf.train.Saver()
     # you may want to save the model
-    save_path = saver.save(sess, "model.ckpt")
+    save_path = saver.save(sess, "./model.ckpt")
     print("Model saved in file: %s" % save_path)
     sess.close()
 


### PR DESCRIPTION
bug fix of example/tutorial_mnist.py (bug on win10_x86_64,linux not sure)

bug fix: "ValueError: Parent directory of model.ckpt doesn't exist, can't save."

error info:
    main_test_denoise_AE(model='sigmoid')       # model = relu, sigmoid
  File "D:/Users/****/Desktop/minst_test/tutorial_mnist.py", line 245, in main_test_denoise_AE
    save_path = saver.save(sess, "model.ckpt")
  File "D:\Explore\Anaconda2\envs\tensorflow\lib\site-packages\tensorflow\python\training\saver.py", line 1314, in save
    "Parent directory of {} doesn't exist, can't save.".format(save_path))
ValueError: Parent directory of model.ckpt doesn't exist, can't save.

platform info:
win10_x86_64
Python 3.5.2 |Continuum Analytics, Inc.| (default, Jul  5 2016, 11:41:13) [MSC v.1900 64 bit (AMD64)]