### PR TITLE
Modify the description for 3D Pooling of PoolLayer.

### DIFF
--- a/tensorlayer/layers.py
+++ b/tensorlayer/layers.py
@@ -2906,7 +2906,7 @@ class PoolLayer(Layer):
     """
     The :class:`PoolLayer` class is a Pooling layer, you can choose
     ``tf.nn.max_pool`` and ``tf.nn.avg_pool`` for 2D or
-    ``tf.nn.max_pool3d()`` and ``tf.nn.avg_pool3d()`` for 3D.
+    ``tf.nn.max_pool3d`` and ``tf.nn.avg_pool3d`` for 3D.
 
     Parameters
     ----------


### PR DESCRIPTION
When using PoolLayer for 3D Pooling, we can use as follows:
tl.layers.PoolLayer(x, pool=tf.nn.max_pool3d)

So the old description "you can choose tf.nn.max_pool and tf.nn.avg_pool for 2D or tf.nn.max_pool3d() and tf.nn.avg_pool3d() for 3D." is not exactly precise.
We eliminate the brackets of "tf.nn.max_pool3d()" and "tf.nn.avg_pool3d()" to be precise.