### PR TITLE
Update installation.rst

### DIFF
--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -184,7 +184,7 @@ The NVIDIA CUDA® Deep Neural Network library (cuDNN) is a GPU-accelerated libra
 
 `cuDNN download <https://developer.nvidia.com/cuDNN>`_
 
-After extracting cuDNN, you will get three folders (bin, lib, include). Then these folders should be copied to CUDA installation. (The default installation directory is `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v8.0`)
+After extracting cuDNN, you will get three folders (bin, lib, include). Then these folders should be copied to CUDA installation. (The default installation directory is `C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v8.0`)
 
 Installing TensorLayer
 ------------------------
@@ -193,8 +193,8 @@ You can easily install Tensorlayer using pip in CMD：
 .. code-block:: bash
 
   pip install tensorflow        #CPU version
-  pip install tensorflow-gpu    #CPU version
-  pip install tensorlayer       #CPU version
+  pip install tensorflow-gpu    #GPU version
+  pip install tensorlayer       #Install tensorlayer
 
 Test
 --------


### PR DESCRIPTION
  line195-197
  pip install tensorflow        #CPU version
  pip install tensorflow-gpu    #GPU version
  pip install tensorlayer       #Install tensorlayer
line 187
After extracting cuDNN, you will get three folders (bin, lib, include). Then these folders should be copied to CUDA installation. (The default installation directory is `C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v8.0`)