### PR TITLE
Fix #188 : Issues with ops.exit_tf, and add ops.open_tb()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tensorlayer.egg-info
 data/.DS_Store
 *.pyc
 *.gz
+.spyproject/

--- a/docs/modules/ops.rst
+++ b/docs/modules/ops.rst
@@ -19,9 +19,13 @@ Operation system, more functions can be found in `TensorFlow API <https://www.te
 TensorFlow functions
 ---------------------------
 
-Kill nvidia process
-^^^^^^^^^^^^^^^^^^^^^^^
+Close TF session and associated processes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autofunction:: exit_tf
+
+Open tensorboard
+^^^^^^^^^^^^^^^^^^^
+.. autofunction:: open_tb
 
 Delete placeholder
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tensorlayer/ops.py
+++ b/tensorlayer/ops.py
@@ -5,36 +5,73 @@
 
 
 import tensorflow as tf
+import tensorlayer as tl
 import os
+import subprocess
 import sys
 from sys import platform as _platform
+from sys import exit as _exit
 
 
-def exit_tf(sess=None):
-    """Close tensorboard and nvidia-process if available
+def exit_tf(sess=None, port=6006):
+    """Close tensorflow session, tensorboard and nvidia-process if available
 
     Parameters
     ----------
     sess : a session instance of TensorFlow
         TensorFlow session
+    tb_port : an integer
+        TensorBoard port you want to close, 6006 is tensorboard default
     """
     text = "[tl] Close tensorboard and nvidia-process if available"
-    sess.close()
+    text2 = "[tl] Close tensorboard and nvidia-process not yet supported by this function (tl.ops.exit_tf) on "
+    if sess != None:
+        sess.close()
     # import time
     # time.sleep(2)
     if _platform == "linux" or _platform == "linux2":
         print('linux: %s' % text)
         os.system('nvidia-smi')
-        os.system('fuser 6006/tcp -k')  # kill tensorboard 6006
+        os.system('fuser '+ port +'/tcp -k')  # kill tensorboard 6006
         os.system("nvidia-smi | grep python |awk '{print $3}'|xargs kill") # kill all nvidia-smi python process
+        _exit()
     elif _platform == "darwin":
         print('OS X: %s' % text)
-        os.system("lsof -i tcp:6006 | grep -v PID | awk '{print $2}' | xargs kill") # kill tensorboard 6006
+        subprocess.Popen("lsof -i tcp:"+ str(port) +"  | grep -v PID | awk '{print $2}' | xargs kill", shell=True) # kill tensorboard
     elif _platform == "win32":
-        print('Windows: %s' % text)
+        print(text2 + "Windows")
+        # TODO
     else:
-        print(_platform)
-    exit()
+        print(text2 + _platform)
+    
+def open_tb(logdir='/tmp/tensorflow', port=6006):
+    """Open tensorboard
+    
+    Parameters
+    ----------
+    logdir : a string
+        Directory where your tensorboard logs are saved
+    port : an integer
+        TensorBoard port you want to open, 6006 is tensorboard default
+    """
+
+    text = "[tl] Open tensorboard, go to localhost:" + str(port) + " to access"
+    text2 = " not yet supported by this function (tl.ops.open_tb)"
+    
+    if not tl.files.exists_or_mkdir(logdir, verbose=False):
+        print("[tl] Log reportory was created at %s" % logdir)
+    
+    if _platform == "linux" or _platform == "linux2":
+        print('linux %s' % text2)
+        # TODO
+    elif _platform == "darwin":
+        print('OS X: %s' % text)
+        subprocess.Popen(sys.prefix + " | python -m tensorflow.tensorboard --logdir=" + logdir + " --port=" + str(port), shell=True) # open tensorboard in localhost:6006/ or whatever port you chose
+    elif _platform == "win32":
+        print('Windows%s' % text2)
+        # TODO
+    else:
+        print(_platform + text2)
 
 def clear_all(printable=True):
     """Clears all the placeholder variables of keep prob,


### PR DESCRIPTION
ops.exit_tf() : changes to avoid throwing exceptions (see issue #188),
added “port” as argument, some work still needed (for windows). Also,
it might be better to separate the functions performed by this into
subcomponent
Ops.open_tb() : self explanatory but only works on Mac for now => if
anyone can implement and test on linux and windows, please do