### PR TITLE
Fixed hard coded filename read

### DIFF
--- a/tensorlayer/nlp.py
+++ b/tensorlayer/nlp.py
@@ -410,7 +410,7 @@ def simple_read_words(filename="nietzsche.txt"):
     --------
     The context in a string
     """
-    with open("nietzsche.txt", "r") as f:
+    with open(filename, "r") as f:
         words = f.read()
         return words
 


### PR DESCRIPTION
The current `simple_read_words()` function uses a hardcoded text file to execute the read method. This has been replaced with the filename argument.