### PR TITLE
disable stdout buffer in binary mode

### DIFF
--- a/tensorlayer/distributed.py
+++ b/tensorlayer/distributed.py
@@ -10,7 +10,7 @@ import time
 # Disable buffer for stdout.
 # When running in container, or other environments where stdout is redirected,
 # the default buffer behavior will seriously delay the message written by `print`.
-sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
 
 class TaskSpecDef(object):
     """Specification for the distributed task with the job name, index of the task,


### PR DESCRIPTION
per commend on https://github.com/zsdonghao/tensorlayer/pull/259, python3 can't have unbuffered text I/O.